### PR TITLE
Ensure sass-lint-underdog fails on warnings

### DIFF
--- a/bin/sass-lint-underdog
+++ b/bin/sass-lint-underdog
@@ -48,6 +48,11 @@ files.forEach(function handleEachFile (file) {
     errorCode = 1;
   }
 
+  // Make sure we fail on warnings as well
+  if (sassLint.warningCount(detects).count) {
+    errorCode = 1;
+  }
+
   sassLint.failOnError(detects);
 });
 


### PR DESCRIPTION
We noticed that `sass-lint-underdog` was not failing when warnings were raised, this is an issue.

This change makes sure that `sass-lint-underdog` fails whenever an error or warning is found.
